### PR TITLE
feat(apigateway): map request-contract errors to 400 instead of 500

### DIFF
--- a/acai_aws/apigateway/router.py
+++ b/acai_aws/apigateway/router.py
@@ -94,10 +94,6 @@ class Router:
             self.__after_all(request, response, endpoint.requirements)
 
     def __handle_contract_error(self, request, response, error):
-        # Request-contract violations (pydantic schema validation, malformed JSON
-        # body) are client errors, not server faults. Respond 400 and surface
-        # each failure via set_error so the response carries the standard
-        # errors[] contract, instead of falling through to a generic 500.
         try:
             response.code = 400
             if isinstance(error, ValidationError):

--- a/acai_aws/apigateway/router.py
+++ b/acai_aws/apigateway/router.py
@@ -1,4 +1,7 @@
+import json
 import logging
+
+from pydantic import ValidationError
 
 from acai_aws.apigateway.exception import ApiException, ApiTimeOutException
 from acai_aws.apigateway.request import Request
@@ -45,6 +48,8 @@ class Router:
         except ApiException as api_error:
             kwargs = {'code': api_error.code, 'key_path': api_error.key_path, 'message': api_error.message, 'error': api_error}
             self.__handle_error(request, response, self.__on_error, **kwargs)
+        except (ValidationError, json.JSONDecodeError) as contract_error:
+            self.__handle_contract_error(request, response, contract_error)
         except Exception as error:
             output = str(error) if self.__output_error else 'internal service error'
             kwargs = {'code': 500, 'key_path': 'unknown', 'message': output, 'error': error}
@@ -87,6 +92,29 @@ class Router:
     def __run_after_all(self, request, response, endpoint):
         if not response.has_errors and self.__after_all and callable(self.__after_all):
             self.__after_all(request, response, endpoint.requirements)
+
+    def __handle_contract_error(self, request, response, error):
+        # Request-contract violations (pydantic schema validation, malformed JSON
+        # body) are client errors, not server faults. Respond 400 and surface
+        # each failure via set_error so the response carries the standard
+        # errors[] contract, instead of falling through to a generic 500.
+        try:
+            response.code = 400
+            if isinstance(error, ValidationError):
+                details = error.errors()
+                for item in details:
+                    location = '.'.join(str(part) for part in (item.get('loc') or ()))
+                    response.set_error(key_path=location or 'unknown', message=item.get('msg', 'invalid'))
+                if not details:
+                    response.set_error(key_path='unknown', message='request failed validation')
+            else:
+                response.set_error(key_path='body', message=f'request body is not valid JSON: {error}')
+            if self.__on_error and callable(self.__on_error):
+                self.__on_error(request, response, error)
+            else:
+                logger.log(level='ERROR', log={'request': request, 'response': response, 'error': error})
+        except Exception as exception:
+            logging.exception(exception)
 
     def __handle_error(self, request, response, error_func=None, **kwargs):
         try:

--- a/acai_aws/apigateway/router.py
+++ b/acai_aws/apigateway/router.py
@@ -93,33 +93,33 @@ class Router:
         if not response.has_errors and self.__after_all and callable(self.__after_all):
             self.__after_all(request, response, endpoint.requirements)
 
+    @staticmethod
+    def __contract_errors(error):
+        if isinstance(error, ValidationError):
+            errors = [
+                ('.'.join(str(part) for part in (item.get('loc') or ())) or 'unknown', item.get('msg', 'invalid'))
+                for item in error.errors()
+            ]
+            return errors or [('unknown', 'request failed validation')]
+        return [('body', f'request body is not valid JSON: {error}')]
+
     def __handle_contract_error(self, request, response, error):
-        try:
-            response.code = 400
-            if isinstance(error, ValidationError):
-                details = error.errors()
-                for item in details:
-                    location = '.'.join(str(part) for part in (item.get('loc') or ()))
-                    response.set_error(key_path=location or 'unknown', message=item.get('msg', 'invalid'))
-                if not details:
-                    response.set_error(key_path='unknown', message='request failed validation')
-            else:
-                response.set_error(key_path='body', message=f'request body is not valid JSON: {error}')
-            if self.__on_error and callable(self.__on_error):
-                self.__on_error(request, response, error)
-            else:
-                logger.log(level='ERROR', log={'request': request, 'response': response, 'error': error})
-        except Exception as exception:
-            logging.exception(exception)
+        response.code = 400
+        for key_path, message in self.__contract_errors(error):
+            response.set_error(key_path=key_path, message=message)
+        self.__dispatch_error(request, response, self.__on_error, error)
 
     def __handle_error(self, request, response, error_func=None, **kwargs):
+        response.code = kwargs['code']
+        response.set_error(key_path=kwargs['key_path'], message=kwargs['message'])
+        self.__dispatch_error(request, response, error_func, kwargs.get('error'))
+
+    def __dispatch_error(self, request, response, error_func, error):
         try:
-            response.code = kwargs['code']
-            response.set_error(key_path=kwargs['key_path'], message=kwargs['message'])
             if error_func and callable(error_func):
-                error_func(request, response, kwargs.get('error'))
+                error_func(request, response, error)
             else:
-                logger.log(level='ERROR', log={'request': request, 'response': response, 'error': kwargs})
+                logger.log(level='ERROR', log={'request': request, 'response': response, 'error': error})
         except Exception as exception:
             logging.exception(exception)
 

--- a/tests/acai_aws/apigateway/router/test_mapping_router.py
+++ b/tests/acai_aws/apigateway/router/test_mapping_router.py
@@ -15,6 +15,8 @@ class RouterMappingTest(unittest.TestCase):
     raise_exception_event = mock_request.get_raised_exception_post()
     mock_request = mock_request
     unhandled_exception_event = mock_request.get_unhandled_exception_post()
+    validation_error_event = mock_request.get_validation_error_post()
+    bad_json_event = mock_request.get_bad_json_post()
     expected_open_headers = {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Headers': '*'
@@ -25,6 +27,8 @@ class RouterMappingTest(unittest.TestCase):
         'optional-params': 'tests/mocks/apigateway/router/mapping_handlers/optional_params.py',
         'raise-exception': 'tests/mocks/apigateway/router/mapping_handlers/raise_exception.py',
         'unhandled-exception': 'tests/mocks/apigateway/router/mapping_handlers/unhandled_exception.py',
+        'raise-validation-error': 'tests/mocks/apigateway/router/mapping_handlers/raise_validation_error.py',
+        'raise-bad-json': 'tests/mocks/apigateway/router/mapping_handlers/raise_bad_json.py',
         'nested/reqs': 'tests/mocks/apigateway/router/mapping_handlers/nested/reqs.py',
         'nested/{id}': 'tests/mocks/apigateway/router/mapping_handlers/nested/nested_id.py'
     }
@@ -108,6 +112,33 @@ class RouterMappingTest(unittest.TestCase):
         self.assertEqual(500, result['statusCode'])
         self.assertDictEqual(self.expected_open_headers, result['headers'])
         self.assertDictEqual({'errors': [{'key_path': 'unknown', 'message': "name 'UnknownException' is not defined"}]}, json_dict_response)
+
+    def test_pydantic_validation_error_returns_400(self):
+        router = Router(
+            base_path=self.base_path,
+            handlers=self.handler_mapping,
+            schema=self.schema_path,
+            output_error=True
+        )
+        result = router.route(self.validation_error_event, None)
+        json_dict_response = json.loads(result['body'])
+        self.assertEqual(400, result['statusCode'])
+        self.assertDictEqual(self.expected_open_headers, result['headers'])
+        self.assertEqual(1, len(json_dict_response['errors']))
+        self.assertEqual('phone', json_dict_response['errors'][0]['key_path'])
+
+    def test_invalid_json_body_returns_400(self):
+        router = Router(
+            base_path=self.base_path,
+            handlers=self.handler_mapping,
+            schema=self.schema_path,
+            output_error=True
+        )
+        result = router.route(self.bad_json_event, None)
+        json_dict_response = json.loads(result['body'])
+        self.assertEqual(400, result['statusCode'])
+        self.assertDictEqual(self.expected_open_headers, result['headers'])
+        self.assertEqual('body', json_dict_response['errors'][0]['key_path'])
 
     def test_basic_mapping_routing_works_and_before_all_function_called(self):
         router = Router(

--- a/tests/mocks/apigateway/mock_request.py
+++ b/tests/mocks/apigateway/mock_request.py
@@ -621,6 +621,60 @@ def get_unhandled_exception_post():
     }
 
 
+def get_validation_error_post():
+    return {
+        'headers': {
+            'x-api-key': 'SOME-KEY',
+            'content-type': 'application/json'
+        },
+        'requestContext': {
+            'resourceId': 't89kib',
+            'authorizer': {
+                'x-authorizer-key': 'SOME KEY',
+                'principalId': '9de3f415a97e410386dbef146e88744e',
+                'integrationLatency': 572,
+            }
+        },
+        'path': 'unit-test/v1/raise-validation-error',
+        'pathParameters': {
+            'proxy': 'hello'
+        },
+        'resource': '/{proxy+}',
+        'httpMethod': 'POST',
+        'queryStringParameters': {
+            'name': 'me'
+        },
+        'body': json.dumps({'body_key': 'body_value'})
+    }
+
+
+def get_bad_json_post():
+    return {
+        'headers': {
+            'x-api-key': 'SOME-KEY',
+            'content-type': 'application/json'
+        },
+        'requestContext': {
+            'resourceId': 't89kib',
+            'authorizer': {
+                'x-authorizer-key': 'SOME KEY',
+                'principalId': '9de3f415a97e410386dbef146e88744e',
+                'integrationLatency': 572,
+            }
+        },
+        'path': 'unit-test/v1/raise-bad-json',
+        'pathParameters': {
+            'proxy': 'hello'
+        },
+        'resource': '/{proxy+}',
+        'httpMethod': 'POST',
+        'queryStringParameters': {
+            'name': 'me'
+        },
+        'body': json.dumps({'body_key': 'body_value'})
+    }
+
+
 def get_basic_for_validation():
     return {
         'headers': {

--- a/tests/mocks/apigateway/router/mapping_handlers/raise_bad_json.py
+++ b/tests/mocks/apigateway/router/mapping_handlers/raise_bad_json.py
@@ -1,0 +1,11 @@
+import json
+
+from acai_aws.apigateway.requirements import requirements
+
+
+@requirements()
+def post(request, response):
+    # A handler parsing JSON itself (e.g. a nested payload) hits a decode error
+    # on malformed input; that is a client contract error, not a server fault.
+    json.loads('{not valid json')
+    return response

--- a/tests/mocks/apigateway/router/mapping_handlers/raise_validation_error.py
+++ b/tests/mocks/apigateway/router/mapping_handlers/raise_validation_error.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+from acai_aws.apigateway.requirements import requirements
+
+
+class _OwnerModel(BaseModel):
+    phone: str
+
+
+@requirements()
+def post(request, response):
+    response.body = {'router_mapping_basic': request.body}
+    # Missing required 'phone' raises pydantic ValidationError (v1 and v2),
+    # mirroring a handler building a request model from a bad body.
+    _OwnerModel()
+    return response


### PR DESCRIPTION
## What
The apigateway `Router` now maps **request-contract violations to 400** instead of letting them fall through to a generic 500:
- `pydantic.ValidationError` (a handler building a request model from a bad body)
- `json.JSONDecodeError` (malformed JSON body)

## Why
These are client errors, not server faults. Today they hit the Router's catch-all `except Exception` and return `500 internal service error`, which hides the real problem from callers and looks like an outage.

## How
- New `except (ValidationError, json.JSONDecodeError)` branch in `route()`, before the generic handler.
- New `__handle_contract_error()` sets `code=400` and surfaces **each** failure via `response.set_error(...)`, so the response carries the standard `errors[]` contract (one entry per invalid field for validation; a single `body` entry for bad JSON). Routed through `on_error` so apps can still hook it.
- `ApiException` (e.g. 418) and unhandled exceptions (500) are unchanged.

## Tests
- `test_pydantic_validation_error_returns_400`, `test_invalid_json_body_returns_400` (mapping router) + 2 mock handlers and 2 mock_request builders.
- Full apigateway suite green locally: 291 passed.