### PR TITLE
logger: dedupe equal RedactionFilters on register_callback

### DIFF
--- a/acai_aws/common/logger/common_logger.py
+++ b/acai_aws/common/logger/common_logger.py
@@ -34,6 +34,8 @@ class CommonLogger:
 
     @classmethod
     def register_callback(cls, callback):
+        if callback in cls._callbacks:
+            return
         cls._callbacks.append(callback)
 
     @classmethod

--- a/acai_aws/common/logger/redaction.py
+++ b/acai_aws/common/logger/redaction.py
@@ -7,8 +7,21 @@ class RedactionFilter:
 
     def __init__(self, **kwargs):
         self._keys = {str(key).lower() for key in kwargs.get('keys') or []}
-        self._patterns = [re.compile(pattern) for pattern in kwargs.get('patterns') or []]
+        self._pattern_sources = tuple(kwargs.get('patterns') or [])
+        self._patterns = [re.compile(pattern) for pattern in self._pattern_sources]
         self._redact_with = kwargs.get('redact_with', self.DEFAULT_REDACTION)
+
+    def __eq__(self, other):
+        if not isinstance(other, RedactionFilter):
+            return NotImplemented
+        return (
+            self._keys == other._keys
+            and self._pattern_sources == other._pattern_sources
+            and self._redact_with == other._redact_with
+        )
+
+    def __hash__(self):
+        return hash((frozenset(self._keys), self._pattern_sources, self._redact_with))
 
     def __call__(self, record):
         if isinstance(record, dict) and 'log' in record:

--- a/tests/acai_aws/common/test_logger.py
+++ b/tests/acai_aws/common/test_logger.py
@@ -212,5 +212,15 @@ class LoggerCallbackTest(TestCase):
         CommonLogger.reset_callbacks()
         self.assertEqual(0, len(CommonLogger._callbacks))
 
+    def test_register_callback_dedupes_equal_filters(self):
+        CommonLogger.register_callback(RedactionFilter(keys=['email']))
+        CommonLogger.register_callback(RedactionFilter(keys=['email']))
+        self.assertEqual(1, len(CommonLogger._callbacks))
+
+    def test_register_callback_keeps_distinct_filters(self):
+        CommonLogger.register_callback(RedactionFilter(keys=['email']))
+        CommonLogger.register_callback(RedactionFilter(keys=['phone']))
+        self.assertEqual(2, len(CommonLogger._callbacks))
+
     def test_common_logger_is_singleton(self):
         self.assertIs(CommonLogger(), CommonLogger())

--- a/tests/acai_aws/common/test_redaction.py
+++ b/tests/acai_aws/common/test_redaction.py
@@ -60,3 +60,18 @@ class RedactionFilterTest(TestCase):
         self.assertEqual('[REDACTED]', log['email'])
         self.assertNotIn('123-45-6789', log['message'])
         self.assertNotIn('ada@example.com', log['message'])
+
+    def test_equal_filters_compare_equal_and_hash_equal(self):
+        one = RedactionFilter(keys=['email', 'ssn'], patterns=[r'\d{3}'], redact_with='*')
+        two = RedactionFilter(keys=['ssn', 'email'], patterns=[r'\d{3}'], redact_with='*')
+        self.assertEqual(one, two)
+        self.assertEqual(hash(one), hash(two))
+
+    def test_filters_with_different_config_are_not_equal(self):
+        base = RedactionFilter(keys=['email'], patterns=[r'\d{3}'])
+        self.assertNotEqual(base, RedactionFilter(keys=['email'], patterns=[r'\d{4}']))
+        self.assertNotEqual(base, RedactionFilter(keys=['phone'], patterns=[r'\d{3}']))
+        self.assertNotEqual(base, RedactionFilter(keys=['email'], patterns=[r'\d{3}'], redact_with='*'))
+
+    def test_not_equal_to_non_filter(self):
+        self.assertNotEqual(RedactionFilter(keys=['email']), 'not-a-filter')


### PR DESCRIPTION
## What

- `RedactionFilter` gains value equality: `__eq__` / `__hash__` over its `keys`, pattern sources, and `redact_with`.
- `CommonLogger.register_callback` skips a callback that already compares equal (dedup).

## Why

Each handler entrypoint calls `LogFilter.register()` at import. A process that loads more than one entrypoint (test suites, multi-handler processes) previously stacked N identical `RedactionFilter`s and scrubbed every record N times. Now it's idempotent — register the same filter as many times as you like, it lands once. Genuinely different callbacks still stack.

Fixes the duplicate-registration footgun at the framework level (vs a per-repo guard in every consumer's bootstrap).

## Validation

- `pytest tests/acai_aws`: **615 passed** (5 new: filter equality/inequality + register dedup).
- `pylint acai_aws --recursive=y --fail-under 10`: **10.00/10**.

Backward compatible. Warrants a patch release (2.8.1).
